### PR TITLE
I've added a filter to the pipeline that will redirect http calls to …

### DIFF
--- a/src/main/scala/filters/TLSFilter.scala
+++ b/src/main/scala/filters/TLSFilter.scala
@@ -27,12 +27,17 @@ import play.api.{Environment, Mode}
 import scala.concurrent.{ExecutionContext, Future}
 
 class TLSFilter @Inject()(env: Environment)(implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
+
   import play.api.mvc.Results._
 
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
     if ((env.mode !== Mode.Prod) || rh.secure) next(rh)
     else {
-      Future.successful(MovedPermanently(s"https://${rh.host}/${rh.uri}"))
+      val url = rh.uri.trim match {
+        case "" | "/" => s"https://${rh.host}"
+        case uri => s"https://${rh.host}/${uri}"
+      }
+      Future.successful(MovedPermanently(url))
     }
   }
 }

--- a/src/main/scala/filters/TLSFilter.scala
+++ b/src/main/scala/filters/TLSFilter.scala
@@ -38,14 +38,14 @@ class TLSFilter @Inject()(env: Environment)(implicit val mat: Materializer, ec: 
     }
   }
 
-  def forwardedFromHttps(rh:RequestHeader):Boolean = {
+  def forwardedFromHttps(rh: RequestHeader): Boolean = {
     rh.headers.get("X-Forwarded-Proto") match {
       case Some("https") => true
       case _ => false
     }
   }
 
-  private def urlFor(rh: RequestHeader) = {
+  private def urlFor(rh: RequestHeader): String = {
     rh.uri.trim match {
       case "" | "/" => s"https://${rh.host}"
       case uri => s"https://${rh.host}$uri"

--- a/src/main/scala/filters/TLSFilter.scala
+++ b/src/main/scala/filters/TLSFilter.scala
@@ -48,7 +48,7 @@ class TLSFilter @Inject()(env: Environment)(implicit val mat: Materializer, ec: 
   private def urlFor(rh: RequestHeader) = {
     rh.uri.trim match {
       case "" | "/" => s"https://${rh.host}"
-      case uri => s"https://${rh.host}/${uri}"
+      case uri => s"https://${rh.host}$uri"
     }
   }
 }


### PR DESCRIPTION
…https in production using a MovedPermanently (301) status. I've added this after the request logging filter so we'll see both the original http call and the redirected call in the logs