### PR TITLE
Feature/change navigation

### DIFF
--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -27,14 +27,14 @@ GET         /publish/company/:id/colleague                    controllers.Report
 GET         /publish/company/:id/register                     controllers.ReportController.register(id:CompaniesHouseId)
 GET         /publish/company/:id/apply-for-code               controllers.ReportController.applyForAuthCode(id:CompaniesHouseId)
 
-GET         /publish/company/:id/file/long                    controllers.SinglePageFormController.show(id: CompaniesHouseId)
-POST        /publish/company/:id/file/long                    controllers.SinglePageFormController.post(id: CompaniesHouseId)
+GET         /publish/company/:id/file/long                    controllers.SinglePageFormController.show(id: CompaniesHouseId, change: Option[Boolean])
+POST        /publish/company/:id/file/long                    controllers.SinglePageFormController.post(id: CompaniesHouseId, change: Option[Boolean])
 
-GET         /publish/company/:id/file/page/:formName          controllers.MultiPageFormController.show(formName: MultiPageFormName, id: CompaniesHouseId)
-POST        /publish/company/:id/file/page/:formName          controllers.MultiPageFormController.post(formName: MultiPageFormName, id: CompaniesHouseId)
+GET         /publish/company/:id/file/page/:formName          controllers.MultiPageFormController.show(formName: MultiPageFormName, id: CompaniesHouseId, change: Option[Boolean])
+POST        /publish/company/:id/file/page/:formName          controllers.MultiPageFormController.post(formName: MultiPageFormName, id: CompaniesHouseId, change: Option[Boolean])
 
-GET         /publish/company/:id/file/short                   controllers.ShortFormController.show(id:CompaniesHouseId)
-POST        /publish/company/:id/file/short                   controllers.ShortFormController.post(id:CompaniesHouseId)
+GET         /publish/company/:id/file/short                   controllers.ShortFormController.show(id:CompaniesHouseId, change: Option[Boolean])
+POST        /publish/company/:id/file/short                   controllers.ShortFormController.post(id:CompaniesHouseId, change: Option[Boolean])
 
 GET         /publish/company/:id/review/long                  controllers.MultiPageFormReviewController.showReview(id:CompaniesHouseId)
 POST        /publish/company/:id/review/long                  controllers.MultiPageFormReviewController.postReview(id:CompaniesHouseId)
@@ -49,8 +49,8 @@ GET         /publish/:reportId/success                        controllers.Confir
 GET         /report/:reportId                                 controllers.ReportController.view(reportId: ReportId)
 GET         /publish/error/:id                                controllers.ErrorController.invalidScope(id:CompaniesHouseId)
 
-GET         /publish/company/:id/reportingPeriod              controllers.ReportingPeriodController.show(id:CompaniesHouseId)
-POST        /publish/company/:id/reportingPeriod              controllers.ReportingPeriodController.post(id:CompaniesHouseId)
+GET         /publish/company/:id/reportingPeriod              controllers.ReportingPeriodController.show(id:CompaniesHouseId, change: Option[Boolean])
+POST        /publish/company/:id/reportingPeriod              controllers.ReportingPeriodController.post(id:CompaniesHouseId, change: Option[Boolean])
 
 GET         /report-payment-practices/claim-callback          controllers.OAuth2Controller.claimCallback(code: Option[String], state: Option[String], error:Option[String]=None, errorDescription:Option[String]=None, errorCode:Option[String]=None)
 

--- a/src/main/scala/controllers/FormHandler.scala
+++ b/src/main/scala/controllers/FormHandler.scala
@@ -31,8 +31,8 @@ import services.CompanyDetail
 case class FormHandler[T, N <: FormName](
   formName: N,
   form: Form[T],
-  private val renderPageFunction: (Html, CompanyDetail) => (Form[T]) => Html,
-  callPage: (CompanyDetail) => Call
+  private val renderPageFunction: (Html, CompanyDetail, Boolean) => (Form[T]) => Html,
+  private val callPageFunction: (CompanyDetail, Boolean) => Call
 ) {
   def bind(implicit request: Request[Map[String, Seq[String]]]): FormHandler[T, N] = copy(form = form.bindForm)
 
@@ -40,6 +40,9 @@ case class FormHandler[T, N <: FormName](
 
   def bind(data: Map[String, String]): FormHandler[T, N] = copy(form = form.bind(data))
 
-  def renderPage(reportPageHeader: Html, companyDetail: CompanyDetail): Html =
-    renderPageFunction(reportPageHeader, companyDetail)(form)
+  def callPage(companyDetail: CompanyDetail, change: Boolean): Call =
+    callPageFunction(companyDetail, change)
+
+  def renderPage(reportPageHeader: Html, companyDetail: CompanyDetail, change: Boolean): Html =
+    renderPageFunction(reportPageHeader, companyDetail, change)(form)
 }

--- a/src/main/scala/controllers/MultiPageFormController.scala
+++ b/src/main/scala/controllers/MultiPageFormController.scala
@@ -48,52 +48,53 @@ class MultiPageFormController @Inject()(
   import longFormPageModel._
 
   private def publishTitle(companyName: String) = s"Publish a report for $companyName"
+
   private def reportPageHeader(companyDetail: CompanyDetail): Html = h1(s"Publish a report for:<br>${companyDetail.companyName}")
 
   implicit def sessionIdFromRequest(implicit request: CompanyAuthRequest[_]): SessionId = request.sessionId
 
-  def show(formName: MultiPageFormName, companiesHouseId: CompaniesHouseId): Action[AnyContent] = companyAuthAction(companiesHouseId).async { implicit request =>
+  def show(formName: MultiPageFormName, companiesHouseId: CompaniesHouseId, change: Option[Boolean] = None): Action[AnyContent] = companyAuthAction(companiesHouseId).async { implicit request =>
     val companyDetail = request.companyDetail
 
-    handleShowPage(formName, companyDetail)
+    handleShowPage(formName, companyDetail, change.contains(true))
   }
 
-  private[controllers] def handleShowPage(formName: MultiPageFormName, companyDetail: CompanyDetail)(implicit sessionId: SessionId, pageContext: PageContext) = {
+  private[controllers] def handleShowPage(formName: MultiPageFormName, companyDetail: CompanyDetail, change: Boolean)(implicit sessionId: SessionId, pageContext: PageContext) = {
     val title = publishTitle(companyDetail.companyName)
 
     bindUpToPage(formHandlers, formName).map {
-      case FormHasErrors(boundHandler) if boundHandler.formName !== formName => Redirect(boundHandler.callPage(companyDetail))
-      case FormIsBlank(boundHandler) if boundHandler.formName !== formName   => Redirect(boundHandler.callPage(companyDetail))
+      case FormHasErrors(boundHandler) if boundHandler.formName !== formName => Redirect(boundHandler.callPage(companyDetail, change))
+      case FormIsBlank(boundHandler) if boundHandler.formName !== formName   => Redirect(boundHandler.callPage(companyDetail, change))
 
-      case FormHasErrors(boundHandler) => BadRequest(page(title)(boundHandler.renderPage(reportPageHeader(companyDetail), companyDetail)))
+      case FormHasErrors(boundHandler) => BadRequest(page(title)(boundHandler.renderPage(reportPageHeader(companyDetail), companyDetail, change)))
       // Form is blank, so the user hasn't filled it in yet. In this case we don't
       // want to show errors, so use the empty form handler for the formName
-      case FormIsBlank(_) => Ok(page(title)(handlerFor(formName).renderPage(reportPageHeader(companyDetail), companyDetail)))
+      case FormIsBlank(_) => Ok(page(title)(handlerFor(formName).renderPage(reportPageHeader(companyDetail), companyDetail, change)))
 
-      case FormIsOk(handler, value) => Ok(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail)))
+      case FormIsOk(handler, value) => Ok(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail, change)))
     }
   }
 
   //noinspection TypeAnnotation
-  def post(formName: MultiPageFormName, companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
+  def post(formName: MultiPageFormName, companiesHouseId: CompaniesHouseId, change: Option[Boolean] = None) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
     val handler = handlerFor(formName)
 
     for {
       _ <- saveFormData(handler.formName, handler.bind.form)
-      result <- handlePostFormPage(formName, request.companyDetail)
+      result <- handlePostFormPage(formName, request.companyDetail, change.contains(true))
     } yield result
   }
 
-  private def handlePostFormPage(formName: MultiPageFormName, companyDetail: CompanyDetail)(implicit sessionId: SessionId, pageContext: PageContext): Future[Result] = {
+  private def handlePostFormPage(formName: MultiPageFormName, companyDetail: CompanyDetail, change: Boolean)(implicit sessionId: SessionId, pageContext: PageContext): Future[Result] = {
     val title = publishTitle(companyDetail.companyName)
 
     bindUpToPage(formHandlers, formName).map {
-      case FormHasErrors(handler) => BadRequest(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail)))
-      case FormIsBlank(handler)   => BadRequest(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail)))
+      case FormHasErrors(handler) => BadRequest(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail, change)))
+      case FormIsBlank(handler)   => BadRequest(page(title)(handler.renderPage(reportPageHeader(companyDetail), companyDetail, change)))
 
       case FormIsOk(handler, value) => nextFormHandler(handler) match {
-        case Some(nextHandler) => Redirect(nextHandler.callPage(companyDetail))
-        case None              => Redirect(routes.MultiPageFormReviewController.showReview(companyDetail.companiesHouseId))
+        case Some(nextHandler) if !change => Redirect(nextHandler.callPage(companyDetail, change))
+        case _                            => Redirect(routes.MultiPageFormReviewController.showReview(companyDetail.companiesHouseId))
       }
     }
   }

--- a/src/main/scala/controllers/MultiPageFormPageModel.scala
+++ b/src/main/scala/controllers/MultiPageFormPageModel.scala
@@ -73,36 +73,46 @@ class MultiPageFormPageModel @Inject()(validations: Validations, serviceConfig: 
       FormHandler(
         ReportingPeriod,
         emptyReportingPeriod,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[ReportingPeriodFormModel]) => pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.ReportingPeriodController.show(companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) => (form: Form[ReportingPeriodFormModel]) =>
+          pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change: Boolean) =>
+          routes.ReportingPeriodController.show(companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
     case PaymentStatistics =>
       FormHandler(
         PaymentStatistics,
         emptyPaymentStatisticsForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[PaymentStatisticsForm]) => pages.paymentStatisticsForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.MultiPageFormController.show(PaymentStatistics, companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) =>
+          (form: Form[PaymentStatisticsForm]) => pages.paymentStatisticsForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change: Boolean) =>
+          routes.MultiPageFormController.show(PaymentStatistics, companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
     case PaymentTerms      =>
       FormHandler(
         PaymentTerms,
         emptyPaymentTermsForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[PaymentTermsForm]) => pages.paymentTermsForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.MultiPageFormController.show(PaymentTerms, companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) =>
+          (form: Form[PaymentTermsForm]) => pages.paymentTermsForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change: Boolean) =>
+          routes.MultiPageFormController.show(PaymentTerms, companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
     case DisputeResolution =>
       FormHandler(
         DisputeResolution,
         emptyDisputeResolutionForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[DisputeResolutionForm]) => pages.disputeResolutionForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.MultiPageFormController.show(DisputeResolution, companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) =>
+          (form: Form[DisputeResolutionForm]) => pages.disputeResolutionForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change: Boolean) =>
+          routes.MultiPageFormController.show(DisputeResolution, companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
     case OtherInformation  =>
       FormHandler(
         OtherInformation,
         emptyOtherInformationForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[OtherInformationForm]) => pages.otherInformationForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.MultiPageFormController.show(OtherInformation, companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) =>
+          (form: Form[OtherInformationForm]) => pages.otherInformationForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change: Boolean) =>
+          routes.MultiPageFormController.show(OtherInformation, companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
   }
 }

--- a/src/main/scala/controllers/MultiPageFormReviewController.scala
+++ b/src/main/scala/controllers/MultiPageFormReviewController.scala
@@ -93,7 +93,7 @@ class MultiPageFormReviewController @Inject()(
   def postReview(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
     val revise: Boolean = Form(single("revise" -> text)).bindForm.value.contains("Revise")
 
-    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId)))
+    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId, None)))
     else handleBinding(request, handleReviewPost)
   }
 

--- a/src/main/scala/controllers/OAuth2Controller.scala
+++ b/src/main/scala/controllers/OAuth2Controller.scala
@@ -38,6 +38,7 @@ class OAuth2Controller @Inject()(
     Redirect(companyAuthService.authoriseUrl(companiesHouseId), companyAuthService.authoriseParams(companiesHouseId))
   }
 
+  //noinspection TypeAnnotation
   def claimCallback(code: Option[String], state: Option[String], error: Option[String], errorDescription: Option[String], errorCode: Option[String]) =
     SessionAction.async { implicit request =>
       val tokenDetails: Future[Either[Result, OAuthToken]] = code match {
@@ -57,7 +58,7 @@ class OAuth2Controller @Inject()(
             _ <- OptionT.liftF(sessionService.put(request.sessionId, oAuthTokenKey, ref))
             _ <- OptionT.liftF(sessionService.put(request.sessionId, companyDetailsKey, companyDetail))
             _ <- OptionT.liftF(sessionService.put(request.sessionId, emailAddressKey, emailAddress))
-          } yield Redirect(controllers.routes.ReportingPeriodController.show(companyId))
+          } yield Redirect(controllers.routes.ReportingPeriodController.show(companyId, None))
         }.value.map {
           case Some(result) => result
           case None => BadRequest(s"Unable to find company details for state $state")

--- a/src/main/scala/controllers/ReportingPeriodController.scala
+++ b/src/main/scala/controllers/ReportingPeriodController.scala
@@ -55,24 +55,24 @@ class ReportingPeriodController @Inject()(
   private def title(implicit request: CompanyAuthRequest[_]): String = publishTitle(request.companyDetail.companyName)
 
   //noinspection TypeAnnotation
-  def show(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async { implicit request =>
+  def show(companiesHouseId: CompaniesHouseId, change:Option[Boolean]) = companyAuthAction(companiesHouseId).async { implicit request =>
     loadFormData(emptyReportingPeriod, MultiPageFormName.ReportingPeriod).map { form =>
       Ok(page(title)(home, pages.reportingPeriod(reportPageHeader, form, companiesHouseId, df, serviceStartDate)))
     }
   }
 
   //noinspection TypeAnnotation
-  def post(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
+  def post(companiesHouseId: CompaniesHouseId, change: Option[Boolean]) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
     val reportingPeriodForm = emptyReportingPeriod.bindForm
     saveFormData(MultiPageFormName.ReportingPeriod, reportingPeriodForm).map { _ =>
       reportingPeriodForm.fold(
         errs => BadRequest(page(title)(home, pages.reportingPeriod(reportPageHeader, errs, companiesHouseId, df, serviceStartDate))),
         reportingPeriod =>
           if (reportingPeriod.hasQualifyingContracts.toBoolean)
-            if (serviceConfig.multiPageForm) Redirect(routes.MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companiesHouseId))
-            else Redirect(routes.SinglePageFormController.show(companiesHouseId))
+            if (serviceConfig.multiPageForm) Redirect(routes.MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companiesHouseId, change))
+            else Redirect(routes.SinglePageFormController.show(companiesHouseId, change))
           else
-            Redirect(routes.ShortFormController.show(companiesHouseId))
+            Redirect(routes.ShortFormController.show(companiesHouseId, change))
       )
     }
   }

--- a/src/main/scala/controllers/ShortFormPageModel.scala
+++ b/src/main/scala/controllers/ShortFormPageModel.scala
@@ -47,16 +47,20 @@ class ShortFormPageModel @Inject()(validations: Validations, serviceConfig: Serv
       FormHandler(
         ReportingPeriod,
         emptyReportingPeriod,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[ReportingPeriodFormModel]) => pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.ReportingPeriodController.show(companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) => (form: Form[ReportingPeriodFormModel]) =>
+          pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change:Boolean) =>
+          routes.ReportingPeriodController.show(companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
 
     case ShortForm =>
       FormHandler(
         ShortForm,
         emptyShortForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[ShortFormModel]) => pages.shortForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.ShortFormController.show(companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change:Boolean) => (form: Form[ShortFormModel]) =>
+          pages.shortForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change:Boolean) =>
+          routes.ShortFormController.show(companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
   }
 }

--- a/src/main/scala/controllers/ShortFormReviewController.scala
+++ b/src/main/scala/controllers/ShortFormReviewController.scala
@@ -86,7 +86,7 @@ class ShortFormReviewController @Inject()(
     val f: (CompanyAuthRequest[Map[String, Seq[String]]], ReportingPeriodFormModel, ShortFormModel) => Future[Result] = handleReviewPost
     val revise: Boolean = Form(single("revise" -> text)).bindForm.value.contains("Revise")
 
-    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId)))
+    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId, None)))
     else handleBinding(request, f)
   }
 

--- a/src/main/scala/controllers/SinglePageFormController.scala
+++ b/src/main/scala/controllers/SinglePageFormController.scala
@@ -54,37 +54,37 @@ class SinglePageFormController @Inject()(
   implicit def sessionIdFromRequest(implicit request: CompanyAuthRequest[_]): SessionId = request.sessionId
 
   //noinspection TypeAnnotation
-  def show(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async { implicit request =>
+  def show(companiesHouseId: CompaniesHouseId, change: Option[Boolean]) = companyAuthAction(companiesHouseId).async { implicit request =>
     val title = publishTitle(request.companyDetail.companyName)
 
     checkValidFromSession(emptyReportingPeriod, SinglePageFormName.ReportingPeriod.entryName).flatMap {
-      case false => Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId)))
+      case false => Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId, change)))
       case true  => loadFormData(emptyLongForm, SinglePageFormName.SinglePageForm).map { form =>
-        Ok(page(title)(home, pages.longForm(reportPageHeader, form, companiesHouseId, df, serviceStartDate)))
+        Ok(page(title)(home, pages.longForm(reportPageHeader, form, companiesHouseId, df, serviceStartDate, change)))
       }
     }
   }
 
   //noinspection TypeAnnotation
-  def post(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
+  def post(companiesHouseId: CompaniesHouseId, change: Option[Boolean]) = companyAuthAction(companiesHouseId).async(parse.urlFormEncoded) { implicit request =>
     val handler = handlerFor(SinglePageFormName.SinglePageForm)
 
     for {
       _ <- saveFormData(handler.formName, handler.bind.form)
-      result <- handlePostFormPage(handler.formName, request.companyDetail)
+      result <- handlePostFormPage(handler.formName, request.companyDetail, change.contains(true))
     } yield result
   }
 
-  private def handlePostFormPage(formName: SinglePageFormName, companyDetail: CompanyDetail)(implicit request: CompanyAuthRequest[Map[String, Seq[String]]]): Future[Result] = {
+  private def handlePostFormPage(formName: SinglePageFormName, companyDetail: CompanyDetail, change:Boolean)(implicit request: CompanyAuthRequest[Map[String, Seq[String]]]): Future[Result] = {
     val title = publishTitle(companyDetail.companyName)
 
     bindUpToPage(formHandlers, formName).map {
-      case FormHasErrors(handler)   => BadRequest(page(title)(handler.renderPage(reportPageHeader, companyDetail)))
+      case FormHasErrors(handler)   => BadRequest(page(title)(handler.renderPage(reportPageHeader, companyDetail, change)))
       case FormIsOk(handler, value) => nextFormHandler(handler) match {
-        case Some(nextHandler) => Redirect(nextHandler.callPage(companyDetail))
+        case Some(nextHandler) => Redirect(nextHandler.callPage(companyDetail, change))
         case None              => Redirect(routes.SinglePageFormReviewController.showReview(companyDetail.companiesHouseId))
       }
-      case FormIsBlank(handler)     => Ok(page(title)(handler.renderPage(reportPageHeader, request.companyDetail)))
+      case FormIsBlank(handler)     => Ok(page(title)(handler.renderPage(reportPageHeader, request.companyDetail, change)))
     }
   }
 }

--- a/src/main/scala/controllers/SinglePageFormPageModel.scala
+++ b/src/main/scala/controllers/SinglePageFormPageModel.scala
@@ -47,16 +47,20 @@ class SinglePageFormPageModel @Inject()(validations: Validations, serviceConfig:
       FormHandler(
         ReportingPeriod,
         emptyReportingPeriod,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[ReportingPeriodFormModel]) => pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.ReportingPeriodController.show(companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change: Boolean) => (form: Form[ReportingPeriodFormModel]) =>
+          pages.reportingPeriod(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change:Boolean) =>
+          routes.ReportingPeriodController.show(companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
 
     case SinglePageForm =>
       FormHandler(
         SinglePageForm,
         emptyLongForm,
-        (header: Html, companyDetail: CompanyDetail) => (form: Form[LongFormModel]) => pages.longForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate),
-        (companyDetail: CompanyDetail) => routes.ShortFormController.show(companyDetail.companiesHouseId)
+        (header: Html, companyDetail: CompanyDetail, change:Boolean) => (form: Form[LongFormModel]) =>
+          pages.longForm(header, form, companyDetail.companiesHouseId, df, serviceStartDate, if (change) Some(true) else None),
+        (companyDetail: CompanyDetail, change :Boolean) =>
+          routes.ShortFormController.show(companyDetail.companiesHouseId, if (change) Some(true) else None)
       )
   }
 }

--- a/src/main/scala/controllers/SinglePageFormReviewController.scala
+++ b/src/main/scala/controllers/SinglePageFormReviewController.scala
@@ -84,7 +84,7 @@ class SinglePageFormReviewController @Inject()(
     val f: (CompanyAuthRequest[Map[String, Seq[String]]], ReportingPeriodFormModel, LongFormModel) => Future[Result] = handleReviewPost
     val revise: Boolean = Form(single("revise" -> text)).bindForm.value.contains("Revise")
 
-    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId)))
+    if (revise) Future.successful(Redirect(routes.ReportingPeriodController.show(companiesHouseId, None)))
     else handleBinding(request, f)
   }
 

--- a/src/main/scala/controllers/VisualTestController.scala
+++ b/src/main/scala/controllers/VisualTestController.scala
@@ -102,13 +102,13 @@ class VisualTestController @Inject()(
     )
 
     val longForms = Seq(
-      views.html.report.longForm(header, emptyLongForm, id, df, serviceStartDate),
-      views.html.report.longForm(header, emptyLongForm.fill(healthyLongFormModel), id, df, serviceStartDate),
-      views.html.report.longForm(header, emptyLongForm.fillAndValidate(LongFormModel(paymentCodes, unhealthyLongForm)), id, df, serviceStartDate)
+      views.html.report.longForm(header, emptyLongForm, id, df, serviceStartDate, None),
+      views.html.report.longForm(header, emptyLongForm.fill(healthyLongFormModel), id, df, serviceStartDate, None),
+      views.html.report.longForm(header, emptyLongForm.fillAndValidate(LongFormModel(paymentCodes, unhealthyLongForm)), id, df, serviceStartDate, None)
     )
 
     val shortForms = Seq(
-      views.html.report.shortForm(header, emptyShortForm, id, df, serviceStartDate)
+      views.html.report.shortForm(header, emptyShortForm, id, df, serviceStartDate, None)
     )
 
     val formGroups = reviewPageData.formGroups(dummyReportingPeriodModel, healthyLongFormModel)(companyDetail)

--- a/src/main/scala/controllers/VisualTestController.scala
+++ b/src/main/scala/controllers/VisualTestController.scala
@@ -98,7 +98,7 @@ class VisualTestController @Inject()(
     val healthyLongFormModel = LongFormModel(paymentCodes, healthyLongForm)
 
     val reportingPeriods = Seq(
-      views.html.report.reportingPeriod(header, dummyReportingPeriodForm, id, df, serviceStartDate)
+      views.html.report.reportingPeriod(header, dummyReportingPeriodForm, id, df, serviceStartDate, None)
     )
 
     val longForms = Seq(

--- a/src/main/scala/views/html/helpers/FieldCallTable.scala
+++ b/src/main/scala/views/html/helpers/FieldCallTable.scala
@@ -29,26 +29,26 @@ import routes._
 class FieldCallTable @Inject()(serviceConfig: ServiceConfig) {
   def call(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case "reportDates.startDate" =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
     case "reportDates.endDate"   =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
 
     case _ if serviceConfig.multiPageForm =>
       multiPageCall(fieldName)
 
     case _ =>
-      Some(SinglePageFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(SinglePageFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
   }
 
   def multiPageCall(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case s if s.startsWith("paymentStatistics") =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
     case s if s.startsWith("paymentTerms")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
     case "disputeResolution.text" =>
-      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
     case s if s.startsWith("otherInformation")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
 
     case _                                      => None
   }

--- a/src/main/scala/views/html/helpers/FieldCallTable.scala
+++ b/src/main/scala/views/html/helpers/FieldCallTable.scala
@@ -21,35 +21,36 @@ import javax.inject.Inject
 
 import config.ServiceConfig
 import controllers.FormPageDefs.MultiPageFormName
-import controllers.routes
+import controllers.routes._
 import play.api.mvc.Call
 import services.CompanyDetail
-import routes._
 
 class FieldCallTable @Inject()(serviceConfig: ServiceConfig) {
+  private def questionId(fieldName: String): String = s"$fieldName-question"
+
   def call(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case "reportDates.startDate" =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
     case "reportDates.endDate"   =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
 
     case _ if serviceConfig.multiPageForm =>
       multiPageCall(fieldName)
 
     case _ =>
-      Some(SinglePageFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
+      Some(SinglePageFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
   }
 
   def multiPageCall(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case s if s.startsWith("paymentStatistics") =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
     case s if s.startsWith("paymentTerms")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
-    case "disputeResolution.text" =>
-      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
-    case s if s.startsWith("otherInformation")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId, Some(true)).withFragment(s"$fieldName-question"))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
+    case "disputeResolution.text"               =>
+      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
+    case s if s.startsWith("otherInformation")  =>
+      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId, Some(true)).withFragment(questionId(fieldName)))
 
-    case _                                      => None
+    case _ => None
   }
 }

--- a/src/main/scala/views/html/helpers/FieldCallTable.scala
+++ b/src/main/scala/views/html/helpers/FieldCallTable.scala
@@ -29,26 +29,26 @@ import routes._
 class FieldCallTable @Inject()(serviceConfig: ServiceConfig) {
   def call(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case "reportDates.startDate" =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
     case "reportDates.endDate"   =>
-      Some(ReportingPeriodController.show(companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(ReportingPeriodController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
 
     case _ if serviceConfig.multiPageForm =>
       multiPageCall(fieldName)
 
     case _ =>
-      Some(SinglePageFormController.show(companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(SinglePageFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
   }
 
   def multiPageCall(fieldName: String)(implicit companyDetail: CompanyDetail): Option[Call] = fieldName match {
     case s if s.startsWith("paymentStatistics") =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentStatistics, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
     case s if s.startsWith("paymentTerms")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.PaymentTerms, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
     case "disputeResolution.text" =>
-      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.DisputeResolution, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
     case s if s.startsWith("otherInformation")      =>
-      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId).withFragment(fieldName))
+      Some(MultiPageFormController.show(MultiPageFormName.OtherInformation, companyDetail.companiesHouseId, Some(true)).withFragment(fieldName))
 
     case _                                      => None
   }

--- a/src/main/scala/views/html/helpers/ReviewPageData.scala
+++ b/src/main/scala/views/html/helpers/ReviewPageData.scala
@@ -124,7 +124,11 @@ class ReviewPageData @Inject()(fieldCallTable: FieldCallTable) extends HtmlHelpe
     ("Standard payment terms", r.paymentTerms.terms, call("paymentTerms.terms")),
     ("Any changes to standard payment terms", r.paymentTerms.paymentTermsChanged.comment, call("paymentTerms.paymentTermsChanged.changed.yesNo")),
     ("Did you consult or notify your suppliers about changes?",
-      r.paymentTerms.paymentTermsChanged.notified.map(conditionalText), call("paymentTerms.paymentTermsChanged.notified.yesNo")),
+      if (r.paymentTerms.paymentTermsChanged.notified.exists(_.yesNo.toBoolean)) r.paymentTerms.paymentTermsChanged.notified.map(conditionalText)
+      else "N/A",
+      if (r.paymentTerms.paymentTermsChanged.notified.exists(_.yesNo.toBoolean)) call("paymentTerms.paymentTermsChanged.notified.yesNo")
+      else None
+    ),
     ("Maximum contract period in " + days, (r.paymentTerms.maximumContractPeriod, days), call("paymentTerms.maximumContractPeriod")),
     ("Maximum contract period: further information", r.paymentTerms.maximumContractPeriodComment.map(breakLines), call("paymentTerms.maximumContractPeriodComment")),
     ("Further remarks about your payment terms", r.paymentTerms.paymentTermsComment.map(breakLines), call("paymentTerms.paymentTermsComment"))

--- a/src/main/scala/views/html/helpers/ReviewPageData.scala
+++ b/src/main/scala/views/html/helpers/ReviewPageData.scala
@@ -125,7 +125,7 @@ class ReviewPageData @Inject()(fieldCallTable: FieldCallTable) extends HtmlHelpe
     ("Any changes to standard payment terms", r.paymentTerms.paymentTermsChanged.comment, call("paymentTerms.paymentTermsChanged.changed.yesNo")),
     ("Did you consult or notify your suppliers about changes?",
       r.paymentTerms.paymentTermsChanged.notified.map(conditionalText).getOrElse("N/A"),
-      if (r.paymentTerms.paymentTermsChanged.notified.exists(_.yesNo.toBoolean)) call("paymentTerms.paymentTermsChanged.notified.yesNo")
+      if (r.paymentTerms.paymentTermsChanged.comment.yesNo.toBoolean) call("paymentTerms.paymentTermsChanged.notified.yesNo")
       else None
     ),
     ("Maximum contract period in " + days, (r.paymentTerms.maximumContractPeriod, days), call("paymentTerms.maximumContractPeriod")),

--- a/src/main/scala/views/html/helpers/ReviewPageData.scala
+++ b/src/main/scala/views/html/helpers/ReviewPageData.scala
@@ -124,8 +124,7 @@ class ReviewPageData @Inject()(fieldCallTable: FieldCallTable) extends HtmlHelpe
     ("Standard payment terms", r.paymentTerms.terms, call("paymentTerms.terms")),
     ("Any changes to standard payment terms", r.paymentTerms.paymentTermsChanged.comment, call("paymentTerms.paymentTermsChanged.changed.yesNo")),
     ("Did you consult or notify your suppliers about changes?",
-      if (r.paymentTerms.paymentTermsChanged.notified.exists(_.yesNo.toBoolean)) r.paymentTerms.paymentTermsChanged.notified.map(conditionalText)
-      else "N/A",
+      r.paymentTerms.paymentTermsChanged.notified.map(conditionalText).getOrElse("N/A"),
       if (r.paymentTerms.paymentTermsChanged.notified.exists(_.yesNo.toBoolean)) call("paymentTerms.paymentTermsChanged.notified.yesNo")
       else None
     ),

--- a/src/main/scala/views/html/helpers/ReviewPageData.scala
+++ b/src/main/scala/views/html/helpers/ReviewPageData.scala
@@ -147,7 +147,7 @@ class ReviewPageData @Inject()(fieldCallTable: FieldCallTable) extends HtmlHelpe
   )
 
   def paymentCodesRows(shortForm: ShortFormModel)(implicit companyDetail: CompanyDetail): Seq[RowDescriptor] = Seq(
-    (codeOfConductText, shortForm.paymentCodes, Some(routes.ShortFormController.show(companyDetail.companiesHouseId).withFragment("paymentCodes.yesNo")))
+    (codeOfConductText, shortForm.paymentCodes, Some(routes.ShortFormController.show(companyDetail.companiesHouseId, Some(true)).withFragment("paymentCodes.yesNo")))
   )
 
 }

--- a/src/main/twirl/views/report/disputeResolutionForm.scala.html
+++ b/src/main/twirl/views/report/disputeResolutionForm.scala.html
@@ -3,10 +3,16 @@
     disputeResolution: Form[controllers.DisputeResolutionForm],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
 @import FormPageDefs.MultiPageFormName
+
+@buttonLabel = @{
+    if (change.contains(true)) "Review your answers"
+    else "Continue"
+}
 
 <div id=contentStart">
     @shared._errorBox(disputeResolution)
@@ -14,14 +20,14 @@
 <div class="scannable-wrapper">
     @header
 
-    <form action="@routes.MultiPageFormController.post(MultiPageFormName.DisputeResolution, companyId)" method="POST" id="longForm-report">
+    <form action="@routes.MultiPageFormController.post(MultiPageFormName.DisputeResolution, companyId, change)" method="POST" id="longForm-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>
 
         @report._disputeResolution(disputeResolution)
 
-        <input type="submit" class="button" name="Continue" value="Continue">
+        <input type="submit" class="button" name="Continue" value="@buttonLabel">
     </form>
 
     @report._scripts(df, serviceStartDate)

--- a/src/main/twirl/views/report/longForm.scala.html
+++ b/src/main/twirl/views/report/longForm.scala.html
@@ -1,9 +1,10 @@
 @(
-        header: Html,
-        longForm: Form[forms.report.LongFormModel],
-        companyId: CompaniesHouseId,
-        df: DateTimeFormatter,
-        serviceStartDate: LocalDate
+    header: Html,
+    longForm: Form[forms.report.LongFormModel],
+    companyId: CompaniesHouseId,
+    df: DateTimeFormatter,
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
 <div id=contentStart">
@@ -24,7 +25,7 @@
 
     @shared._day1Calculation()
 
-    <form action="@routes.SinglePageFormController.post(companyId)" method="POST" id="longForm-report">
+    <form action="@routes.SinglePageFormController.post(companyId, change)" method="POST" id="longForm-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>

--- a/src/main/twirl/views/report/otherInformationForm.scala.html
+++ b/src/main/twirl/views/report/otherInformationForm.scala.html
@@ -3,7 +3,8 @@
     otherInformation: Form[controllers.OtherInformationForm],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
     @import FormPageDefs.MultiPageFormName
@@ -14,7 +15,7 @@
     <div class="scannable-wrapper">
         @header
 
-        <form action="@routes.MultiPageFormController.post(MultiPageFormName.OtherInformation, companyId)" method="POST" id="longForm-report">
+        <form action="@routes.MultiPageFormController.post(MultiPageFormName.OtherInformation, companyId, change)" method="POST" id="longForm-report">
             <p class="small-aside">
                 Companies House number: @companyId.id
             </p>

--- a/src/main/twirl/views/report/paymentStatisticsForm.scala.html
+++ b/src/main/twirl/views/report/paymentStatisticsForm.scala.html
@@ -3,10 +3,16 @@
     form: Form[controllers.PaymentStatisticsForm],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
 @import FormPageDefs.MultiPageFormName
+
+@buttonLabel = @{
+    if (change.contains(true)) "Review your answers"
+    else "Continue"
+}
 
 <div id=contentStart">
     @shared._errorBox(form)
@@ -26,14 +32,14 @@
 
     @shared._day1Calculation()
 
-    <form action="@routes.MultiPageFormController.post(MultiPageFormName.PaymentStatistics, companyId)" method="POST" id="longForm-report">
+    <form action="@routes.MultiPageFormController.post(MultiPageFormName.PaymentStatistics, companyId, change)" method="POST" id="longForm-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>
 
         @report._paymentStatistics(form)
 
-        <input type="submit" class="button" name="Continue" value="Continue">
+        <input type="submit" class="button" name="Continue" value="@buttonLabel">
     </form>
 
     @report._scripts(df, serviceStartDate)

--- a/src/main/twirl/views/report/paymentTermsForm.scala.html
+++ b/src/main/twirl/views/report/paymentTermsForm.scala.html
@@ -3,10 +3,16 @@
     paymentTerms: Form[controllers.PaymentTermsForm],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
 @import FormPageDefs.MultiPageFormName
+
+@buttonLabel = @{
+    if (change.contains(true)) "Review your answers"
+    else "Continue"
+}
 
 <div id=contentStart">
     @shared._errorBox(paymentTerms)
@@ -14,14 +20,14 @@
 <div class="scannable-wrapper">
     @header
 
-    <form action="@routes.MultiPageFormController.post(MultiPageFormName.PaymentTerms, companyId)" method="POST" id="longForm-report">
+    <form action="@routes.MultiPageFormController.post(MultiPageFormName.PaymentTerms, companyId, change)" method="POST" id="longForm-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>
 
         @report._paymentTerms(paymentTerms)
 
-        <input type="submit" class="button" name="Continue" value="Continue">
+        <input type="submit" class="button" name="Continue" value="@buttonLabel">
     </form>
 
     @report._scripts(df, serviceStartDate)

--- a/src/main/twirl/views/report/reportingPeriod.scala.html
+++ b/src/main/twirl/views/report/reportingPeriod.scala.html
@@ -3,7 +3,8 @@
     reportingPeriodForm: Form[forms.report.ReportingPeriodFormModel],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean] = None
 )(implicit messages: MessagesApi, lang: Lang)
 
 <div id=contentStart">
@@ -35,7 +36,7 @@
         <li>It is <strong>not</strong> for <a rel="external" target="_blank" href="http://www.legislation.gov.uk/ukpga/2015/26/section/2/enacted">financial services</a></li>
     </ul>
 
-    <form action="@routes.ReportingPeriodController.post(companyId)" method="POST" id="longForm-report">
+    <form action="@routes.ReportingPeriodController.post(companyId, change)" method="POST" id="longForm-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>

--- a/src/main/twirl/views/report/reportingPeriod.scala.html
+++ b/src/main/twirl/views/report/reportingPeriod.scala.html
@@ -4,8 +4,13 @@
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
     serviceStartDate: LocalDate,
-    change: Option[Boolean] = None
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
+
+@buttonLabel = @{
+    if (change.contains(true)) "Review your answers"
+    else "Continue"
+}
 
 <div id=contentStart">
     @shared._errorBox(reportingPeriodForm)
@@ -43,7 +48,7 @@
 
         @report._reportingPeriod(reportingPeriodForm)
 
-        <input type="submit" class="button" name="Continue" value="Continue">
+        <input type="submit" class="button" name="Continue" value="@buttonLabel">
     </form>
 
     @report._scripts(df, serviceStartDate)

--- a/src/main/twirl/views/report/shortForm.scala.html
+++ b/src/main/twirl/views/report/shortForm.scala.html
@@ -3,7 +3,8 @@
     shortForm: Form[forms.report.ShortFormModel],
     companyId: CompaniesHouseId,
     df: DateTimeFormatter,
-    serviceStartDate: LocalDate
+    serviceStartDate: LocalDate,
+    change: Option[Boolean]
 )(implicit messages: MessagesApi, lang: Lang)
 
 <div id=contentStart">
@@ -12,7 +13,7 @@
 <div class="scannable-wrapper">
     @header
 
-    <form action="@routes.ShortFormController.post(companyId)" method="POST" id="file-report">
+    <form action="@routes.ShortFormController.post(companyId, change)" method="POST" id="file-report">
         <p class="small-aside">
             Companies House number: @companyId.id
         </p>

--- a/src/main/twirl/views/shared/_dateField.scala.html
+++ b/src/main/twirl/views/shared/_dateField.scala.html
@@ -18,7 +18,7 @@
 }
 
 <div class="form-group @errorClass(form(fieldName))">
-    <fieldset>
+    <fieldset id="@fieldName-question">
         <legend id="@fieldName">
             <span class="form-label-bold">@messages(s"field.$fieldName.label")</span>
             <span id="error-@fieldName" class="error-message">@errorMessage(form(fieldName))</span>

--- a/src/main/twirl/views/shared/_numberField.scala.html
+++ b/src/main/twirl/views/shared/_numberField.scala.html
@@ -6,6 +6,6 @@
         @shared._hint(fieldName)
         <span id="error-@fieldName" class="error-message">@errorMessage(form(fieldName))</span>
     </label>
-    <input class="form-control form-control-number-wide"  pattern="?[0-9]*" type="number" id=@fieldName name="@fieldName" value="@form(fieldName).value">
+    <input class="form-control form-control-number-wide"  pattern="?[0-9]*" type="number" id="@fieldName" name="@fieldName" value="@form(fieldName).value">
     @unitText.map { text => <span class="number-unit">@text</span> }
 </fieldset>

--- a/src/main/twirl/views/shared/_numberField.scala.html
+++ b/src/main/twirl/views/shared/_numberField.scala.html
@@ -1,11 +1,11 @@
 @(form: Form[_], fieldName: String, unitText: Option[String] = None)(implicit messages: MessagesApi)
 
-<fieldset class='form-group @errorClass(form(fieldName))'>
+<fieldset id="@fieldName-question" class='form-group @errorClass(form(fieldName))'>
     <label for=@fieldName>
         <span class="form-label-bold">@messages(s"field.$fieldName.label")</span>
         @shared._hint(fieldName)
         <span id="error-@fieldName" class="error-message">@errorMessage(form(fieldName))</span>
     </label>
-    <input class="form-control form-control-number-wide"  pattern="?[0-9]*" type="number" id="@fieldName" name="@fieldName" value="@form(fieldName).value">
+    <input class="form-control form-control-number-wide"  pattern="?[0-9]*" type="number" id=@fieldName name="@fieldName" value="@form(fieldName).value">
     @unitText.map { text => <span class="number-unit">@text</span> }
 </fieldset>

--- a/src/main/twirl/views/shared/_textBox.scala.html
+++ b/src/main/twirl/views/shared/_textBox.scala.html
@@ -3,7 +3,7 @@
 @import shared._hint
 
 <div class="form-group @errorClass(form(fieldName))">
-    <fieldset>
+    <fieldset id="@fieldName-question">
         <label for="@fieldName">
             <span class="form-label-bold">@messages(s"field.$fieldName.label")</span>
 

--- a/src/main/twirl/views/shared/_textField.scala.html
+++ b/src/main/twirl/views/shared/_textField.scala.html
@@ -1,7 +1,7 @@
 @(form: Form[_], fieldName: String)(implicit messages: MessagesApi)
 
 <div class="form-group @errorClass(form(fieldName))">
-    <fieldset>
+    <fieldset id="@fieldName-question">
         <label for="@fieldName">
             <span class="form-label-bold">@messages(s"field.$fieldName.label")</span>
             @shared._hint(fieldName)

--- a/src/main/twirl/views/shared/_yesNoField.scala.html
+++ b/src/main/twirl/views/shared/_yesNoField.scala.html
@@ -5,7 +5,7 @@
 }
 
 <div class="form-group @errorClass(form(fieldName))">
-    <fieldset class="inline">
+    <fieldset id="@fieldName-question" class="inline">
         <legend id="@fieldName">
             <span class="form-label-bold">@messages(s"field.$fieldName.label")</span>
             @shared._hint(fieldName)


### PR DESCRIPTION
When the user navigates to a form page from a "Change" link on the review page then the button for the form will say "Review your changes" instead of "Continue" and when they submit the form without errors they will be taken straight back to the review page rather than the next form in the sequence.