### PR TITLE
(copy) Latest version of field hint text

### DIFF
--- a/src/main/resources/messages
+++ b/src/main/resources/messages
@@ -63,7 +63,7 @@ field.hasQualifyingContracts.hint=
 field.paymentStatistics.averageDaysToPay.label=Average time to pay in days
 field.paymentStatistics.averageDaysToPay.hint=The average time it took to make payments under qualifying contracts in the reporting period.
 
-field.paymentStatistics.percentPaidLaterThanAgreedTerms.label=Percentage of payments due in the reporting period which have not been paid within the agreed period
+field.paymentStatistics.percentPaidLaterThanAgreedTerms.label=Payments due in the reporting period which have not been paid within the agreed period
 field.paymentStatistics.percentPaidLaterThanAgreedTerms.hint=This relates to the number of invoices, not their value.
 
 field.paymentStatistics.percentageSplit.percentWithin30Days.name=Percentage of payments made between day 1 and day 30
@@ -73,26 +73,35 @@ field.paymentStatistics.percentageSplit.percentWithin30Days.hint=
 field.paymentStatistics.percentageSplit.percentWithin60Days.name=Percentage of payments made between day 31 and day 60
 field.paymentStatistics.percentageSplit.percentWithin60Days.label=B) Percentage of invoices paid between day 31 and day 60 (inclusive)
 field.paymentStatistics.percentageSplit.percentWithin60Days.hint=
-      
+
 field.paymentStatistics.percentageSplit.percentBeyond60Days.name=Percentage of payments made on or after day 61
 field.paymentStatistics.percentageSplit.percentBeyond60Days.label=C) Percentage of invoices paid on or after day 61
 field.paymentStatistics.percentageSplit.percentBeyond60Days.hint=
 
 field.paymentTerms.terms.label=Describe your standard payment terms
-field.paymentTerms.terms.hint=This is your business’s standard terms relating to payment for qualifying contracts. This includes (if applicable) your standard payment terms for different types of qualifying contract. If you do not use standard terms then you should use the most frequently used payment terms for qualifying contracts, including for different types of qualifying contract. As well as briefly describing your terms, you could also include a link to your website if the full terms can be found there.
+field.paymentTerms.terms.hint=If you don’t use standard terms, describe the most frequently used payment terms for qualifying contracts, including for different types of qualifying contract.\n\nInclude a link to your website if the full terms can be found there.
+field.paymentTerms.terms.hintHeading=Help with describing standard payment terms
 
 field.paymentTerms.shortestPaymentPeriod.label=Enter your shortest (or only) standard payment period in days
-field.paymentTerms.shortestPaymentPeriod.hint=The standard payment period is the contractual length of time for your business to make payments, as set out in the standard payment terms for qualifying contracts. If your business does not have standard terms, the standard payment period will be the contractual payment period in your business’s most commonly used terms for the reporting period. And if your business uses different terms for different types of qualifying contract, you must give the periods for the different contract types, as set out in the standard or most frequently used terms for each contract type.
+field.paymentTerms.shortestPaymentPeriod.hint=If your business doesn’t have standard terms, provide the contractual payment period in your business’s most commonly used terms for the reporting period.\n\nIf your business uses different terms for different types of qualifying contract, give the shortest period here and the longest in the next field.
+
+field.paymentTerms.shortestPaymentPeriod.hintHeading=Help with standard payment period
+
 field.paymentTerms.longestPaymentPeriod.label=Optional: Enter your longest standard payment period in days
-field.paymentTerms.longestPaymentPeriod.hint=If you only have one standard payment period, you should use only the first box to enter a figure. If you have more than one standard payment period, you must enter the shortest and longest period in days using both boxes, and then describe in the Standard Payment Terms text box what each of you standard payment periods is for. If you have a range instead of a single figure, you should enter the range and then include information in the Standard Payment Terms text box about how the range is calculated.
+field.paymentTerms.longestPaymentPeriod.hint=If you only have one standard payment period, you should only enter a figure in the first box.\n\nUse both boxes if you have more than one standard payment period. Enter the shortest and longest standard period in days and then describe in the standard payment terms text box what each of the standard payment periods is for.\n\nIf you have a range of standard terms, you should enter details of the range and then include information in the standard payment terms text box about how the terms are decided.\n\n
+
+field.paymentTerms.longestPaymentPeriod.hintHeading=Help with longest standard payment period
 
 field.paymentTerms.maximumContractPeriod.label=Enter your maximum contractual payment period
-field.paymentTerms.maximumContractPeriod.hint=The maximum payment period is the longest period for payment that your business agreed to in a qualifying contract entered in the reporting period. This could be different to your longest standard payment terms period.
+field.paymentTerms.maximumContractPeriod.hint=The maximum payment period is the longest period for payment that your business agreed to in a qualifying contract entered in the reporting period.\n\nThis could be different to your longest standard payment terms period.
+field.paymentTerms.maximumContractPeriod.hintHeading=Help with maximum contractual payment period
+
 field.paymentTerms.maximumContractPeriodComment.label=Optional: any further information about your maximum contractual payment period
 field.paymentTerms.maximumContractPeriodComment.hint=For example, if you have different payment periods, depending on the product, company size or any other variation, then you could give the maximum period for each type.
 
 field.paymentTerms.paymentTermsChanged.changed.yesNo.label=Were there any changes to your standard payment terms in the reporting period?
-field.paymentTerms.paymentTermsChanged.changed.yesNo.hint=For example, a business may start the reporting period with a 60-day payment period in their standard contract, but change this to 30-days three months into the reporting period.
+field.paymentTerms.paymentTermsChanged.changed.yesNo.hint=For example, a business may start the reporting period with a 60 day payment period in their standard contract, but change this to 30 days within the reporting period.
+field.paymentTerms.paymentTermsChanged.changed.yesNo.hintHeading=Help with changes to standard payment terms
 field.paymentTerms.paymentTermsChanged.changed.text.label=If so, explain what the changes were
 field.paymentTerms.paymentTermsChanged.changed.text.hint=
 
@@ -105,13 +114,16 @@ field.paymentTerms.paymentTermsComment.label=Optional: any further information a
 field.paymentTerms.paymentTermsComment.hint=
 
 field.disputeResolution.text.label=Describe your dispute resolution process
-field.disputeResolution.text.hint=Describe your dispute resolution process for qualifying contracts How do you resolve disputes and complaints with your suppliers about payments?\n\nThis helps suppliers know who to contact and to understand the process they need to follow to resolve a dispute or concern.\n\nThis may be a detailed process, or simply an explanation that a complaint or concern will be considered by a particular department or job title, the usual timescale and next steps.\n\nIf your business has a dispute resolution process already published on their website, you could include a hyperlink here alongside an explanation of the process.
+field.disputeResolution.text.hint=Describe your dispute resolution process for qualifying contracts.\n\nThis may be a detailed process, or simply an explanation that a complaint or concern will be considered by a particular department or job title, the usual timescale and next steps.\n\nIf this is published on your business’s website, include a link here along with any further details about the process.
+field.disputeResolution.text.hintHeading=Help with describing how you resolve disputes and complaints
 
 field.otherInformation.offerEInvoicing.label=Does your business offer e-invoicing in relation to qualifying contracts?
-field.otherInformation.offerEInvoicing.hint=You must state whether your business'' payment practices and policies provide for invoices to be submitted and tracked electronically, such as with invoice document management systems software.\n\nInvoice document management systems software allows documents to be electronically exchanged, and means a more streamlined process with less manual intervention. This can make the process of payment faster for the supplier.
+field.otherInformation.offerEInvoicing.hint=Confirm whether you allow invoices to be submitted and tracked electronically, such as with invoice document management systems software.\n\nThis allows for a more streamlined process with less manual intervention and can make the process of payment faster for the supplier.\n\nAllowing suppliers to invoice by email doesn’t count as accepting e-invoicing.
+field.otherInformation.offerEInvoicing.hintHeading=Help with e-invoicing
 
 field.otherInformation.offerSupplyChainFinance.label=Does your business offer supply chain finance options?
-field.otherInformation.offerSupplyChainFinance.hint=You must state whether your business'' payment practices and policies include an arrangement under which a supplier which has submitted an invoice can receive payment of the invoiced sum from a finance provider earlier than the agreed payment date, with the large business paying the invoiced sum to the finance provider.
+field.otherInformation.offerSupplyChainFinance.hint=Confirm whether your business's payment practices and policies include an arrangement under which a supplier who has submitted an invoice can receive payment of the invoiced sum from a finance provider earlier than the agreed payment date, with the large business paying the invoiced sum to the finance provider.
+field.otherInformation.offerSupplyChainFinance.hintHeading=Help with supply chain finance options
 
 field.otherInformation.retentionChargesInPolicy.label=Under its payment practices and policies, can your business deduct sums from payments as a charge for remaining on a supplier list?
 field.otherInformation.retentionChargesInPolicy.hint=
@@ -120,7 +132,8 @@ field.otherInformation.retentionChargesInPast.label=In this reporting period, ha
 field.otherInformation.retentionChargesInPast.hint=
 
 field.otherInformation.paymentCodes.yesNo.label=Is your business a member of a code of conduct or standards on payment practices?
-field.otherInformation.paymentCodes.yesNo.hint=A payment code is a voluntary initiative, where signatories agree to undertake certain behaviours as a mark of good practice. For example, signatories to the Prompt Payment Code must commit to paying 95% of their invoices within 60 days unless exceptional circumstances apply.
+field.otherInformation.paymentCodes.yesNo.hint=A payment code is a voluntary initiative, where signatories agree to undertake certain behaviours as a mark of good practice. For example, signatories to the Prompt Payment Code commit to paying 95% of their invoices within 60 days.
+field.otherInformation.paymentCodes.yesNo.hintHeading=Help with codes of conduct and standards on payment practices
 field.otherInformation.paymentCodes.text.label=If so, enter the name of the code of practice
 field.otherInformation.paymentCodes.text.hint=
 

--- a/src/main/twirl/views/shared/_hint.scala.html
+++ b/src/main/twirl/views/shared/_hint.scala.html
@@ -4,9 +4,10 @@
 @import shared._detailPanel
 @import views.html.helpers.HtmlHelpers.breakLines
 
+
 @defining(messages(s"field.$fieldName.hint")) { hintText =>
-    @if(hintText.length > 80) {
-        @_detailPanel(s"$fieldName-detail")(Html("How do I do this?"))(breakLines(hintText))
+    @if(messages.isDefinedAt(s"field.$fieldName.hintHeading")) {
+        @_detailPanel(s"$fieldName-detail")(Html(messages(s"field.$fieldName.hintHeading")))(breakLines(hintText))
     } else {
         <span class="form-hint">@breakLines(hintText)</span>
     }


### PR DESCRIPTION
Changed twister logic to be more explicit: a hint is 'twisted' if the
messages file contains a hintHeading for that field.

Updated copy as per:
https://docs.google.com/document/d/1ydlEb2IwNvp9tBLFZnHGh90j-XXASejVYGREljJ8zU4/edit