### PR TITLE
A common user issue is that they enter 2-digit years instead of 4 dig…

### DIFF
--- a/src/main/scala/forms/Validations.scala
+++ b/src/main/scala/forms/Validations.scala
@@ -51,19 +51,24 @@ object Validations {
   }
 
   def words(minWords: Int = 0, maxWords: Int = Int.MaxValue): Mapping[String] = (minWords, maxWords) match {
-    case (0, Int.MaxValue) => text
+    case (0, Int.MaxValue)   => text
     case (min, Int.MaxValue) => text.verifying(minWordConstraint(min))
-    case (0, max) => text.verifying(maxWordConstraint(max), Constraints.maxLength(max * averageWordLength))
-    case (min, max) =>
+    case (0, max)            => text.verifying(maxWordConstraint(max), Constraints.maxLength(max * averageWordLength))
+    case (min, max)          =>
       text.verifying(
         minWordConstraint(min),
         maxWordConstraint(max), Constraints.maxLength(max * averageWordLength))
   }
 
+  /**
+    * Allow users to enter "17" when they mean "2017" by adjusting numbers below 100.
+    */
+  private val year: Mapping[Int] = number(min = 0).transform(i => if (i < 100) i + 2000 else i, i => i)
+
   private[forms] val dateFields: Mapping[DateFields] = mapping(
-    "day" -> number,
-    "month" -> number,
-    "year" -> number
+    "day" -> number(min = 0),
+    "month" -> number(min = 0),
+    "year" -> year
   )(DateFields.apply)(DateFields.unapply)
     .verifying(errorDate, fields => validateDate(fields))
 


### PR DESCRIPTION
…its (despite help text), so I have implemented logic in the date field handling to trap year values less than 100 and add 2000 to them to normalise them up to the 21st century.