### PR TITLE
Feature/code conversion failure

### DIFF
--- a/src/main/scala/controllers/ErrorController.scala
+++ b/src/main/scala/controllers/ErrorController.scala
@@ -32,8 +32,8 @@ class ErrorController @Inject()(val pageConfig: PageConfig,
     Unauthorized(page("Your session timed out")(home, views.html.errors.sessionTimeout())).removingFromSession(SessionAction.sessionIdKey)
   }
 
+  //noinspection TypeAnnotation
   def invalidScope(companiesHouseId: CompaniesHouseId) = companyAuthAction(companiesHouseId) { implicit request =>
     Ok(page("Your report has not been filed because of an error")(home, views.html.errors.invalidScope(request.companyDetail)))
   }
-
 }

--- a/src/main/scala/controllers/OAuth2Controller.scala
+++ b/src/main/scala/controllers/OAuth2Controller.scala
@@ -17,22 +17,26 @@
 
 package controllers
 
-import javax.inject.Inject
-
 import actions.SessionAction
 import cats.data.OptionT
 import cats.instances.future._
+import config.{PageConfig, ServiceConfig}
+import javax.inject.Inject
 import models.CompaniesHouseId
+import play.api.Logger
 import play.api.mvc._
 import services._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class OAuth2Controller @Inject()(
-                                  sessionService: SessionService,
-                                  companySearchService: CompanySearchService,
-                                  companyAuthService: CompanyAuthService,
-                                  SessionAction: SessionAction)(implicit exec: ExecutionContext) extends Controller {
+  val pageConfig: PageConfig,
+  val serviceConfig: ServiceConfig,
+  sessionService: SessionService,
+  companySearchService: CompanySearchService,
+  companyAuthService: CompanyAuthService,
+  SessionAction: SessionAction
+)(implicit exec: ExecutionContext) extends Controller with PageHelper {
 
   def startOauthDance(companiesHouseId: CompaniesHouseId)(implicit request: RequestHeader): Result = {
     Redirect(companyAuthService.authoriseUrl(companiesHouseId), companyAuthService.authoriseParams(companiesHouseId))
@@ -41,28 +45,37 @@ class OAuth2Controller @Inject()(
   //noinspection TypeAnnotation
   def claimCallback(code: Option[String], state: Option[String], error: Option[String], errorDescription: Option[String], errorCode: Option[String]) =
     SessionAction.async { implicit request =>
-      val tokenDetails: Future[Either[Result, OAuthToken]] = code match {
-        case None => Future.successful(Left(BadRequest("No oAuth code provided")))
-        case Some(c) => companyAuthService.convertCode(c).map(Right(_))
-      }
+      state.map(CompaniesHouseId) match {
+        case None => Future.successful(BadRequest(s"Unable to find company details for state $state"))
 
-      import actions.CompanyAuthAction._
+        case Some(companyId) =>
+          val tokenDetails: Future[Either[Result, OAuthToken]] = code match {
+            case None    => Future.successful(Left(BadRequest("No oAuth code provided")))
+            case Some(c) => companyAuthService.convertCode(c).map {
+              case Left(conversionError) =>
+                Logger.info(s"Got an error trying to convert oAuth code: $conversionError")
+                Left(BadRequest(page("We encountered an error during login")(home, views.html.errors.oauthProblem(companyId))))
+              case Right(token)          => Right(token)
+            }
+          }
 
-      tokenDetails.flatMap {
-        case Left(result) => Future.successful(result)
-        case Right(ref) => {
-          for {
-            companyId <- OptionT.fromOption(state.map(CompaniesHouseId))
-            companyDetail <- OptionT(companySearchService.find(companyId))
-            emailAddress <- OptionT(companyAuthService.emailAddress(companyId, ref))
-            _ <- OptionT.liftF(sessionService.put(request.sessionId, oAuthTokenKey, ref))
-            _ <- OptionT.liftF(sessionService.put(request.sessionId, companyDetailsKey, companyDetail))
-            _ <- OptionT.liftF(sessionService.put(request.sessionId, emailAddressKey, emailAddress))
-          } yield Redirect(controllers.routes.ReportingPeriodController.show(companyId, None))
-        }.value.map {
-          case Some(result) => result
-          case None => BadRequest(s"Unable to find company details for state $state")
-        }
+          import actions.CompanyAuthAction._
+
+          tokenDetails.flatMap {
+            case Left(result) => Future.successful(result)
+            case Right(ref)   => {
+              for {
+                companyDetail <- OptionT(companySearchService.find(companyId))
+                emailAddress <- OptionT(companyAuthService.emailAddress(companyId, ref))
+                _ <- OptionT.liftF(sessionService.put(request.sessionId, oAuthTokenKey, ref))
+                _ <- OptionT.liftF(sessionService.put(request.sessionId, companyDetailsKey, companyDetail))
+                _ <- OptionT.liftF(sessionService.put(request.sessionId, emailAddressKey, emailAddress))
+              } yield Redirect(controllers.routes.ReportingPeriodController.show(companyId, None))
+            }.value.map {
+              case Some(result) => result
+              case None         => BadRequest(s"Unable to find company details for state $state")
+            }
+          }
       }
     }
 }

--- a/src/main/scala/services/CompanyAuthService.scala
+++ b/src/main/scala/services/CompanyAuthService.scala
@@ -21,10 +21,17 @@ import models.CompaniesHouseId
 
 import scala.concurrent.Future
 
+case class OAuthError(error_description: String, error: String)
+
+sealed trait CodeConversionError
+case object CodeAlreadySeen extends CodeConversionError
+case class ErrorInConversion(oAuthError: OAuthError) extends CodeConversionError
+
+
 trait CompanyAuthService {
   def authoriseUrl(companiesHouseId: CompaniesHouseId): String
 
-  def convertCode(code: String): Future[OAuthToken]
+  def convertCode(code: String): Future[Either[CodeConversionError, OAuthToken]]
 
   def refreshAccessToken(oAuthToken: OAuthToken): Future[OAuthToken]
 

--- a/src/main/scala/services/mocks/MockCompanyAuth.scala
+++ b/src/main/scala/services/mocks/MockCompanyAuth.scala
@@ -19,7 +19,7 @@ package services.mocks
 
 import models.CompaniesHouseId
 import org.joda.time.LocalDateTime
-import services.{CompanyAuthService, OAuthToken}
+import services.{CodeConversionError, CompanyAuthService, OAuthToken}
 
 import scala.concurrent.Future
 
@@ -39,10 +39,11 @@ class MockCompanyAuth extends CompanyAuthService {
   override def emailAddress(companiesHouseId: CompaniesHouseId, oAuthToken: OAuthToken): Future[Option[String]] =
     Future.successful(Some(emails.getOrElse(companiesHouseId, "test@barbaz.com")))
 
-
   override def targetScope(companiesHouseId: CompaniesHouseId): String = ""
 
-  override def convertCode(code: String): Future[OAuthToken] = Future.successful(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken"))
+  override def convertCode(code: String): Future[Either[CodeConversionError, OAuthToken]] =
+    Future.successful(Right(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken")))
+  //Future.successful(Left(CodeAlreadySeen))
 
   override def refreshAccessToken(oAuthToken: OAuthToken): Future[OAuthToken] = Future.successful(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken"))
 }

--- a/src/main/scala/services/mocks/MockCompanyAuth.scala
+++ b/src/main/scala/services/mocks/MockCompanyAuth.scala
@@ -19,7 +19,7 @@ package services.mocks
 
 import models.CompaniesHouseId
 import org.joda.time.LocalDateTime
-import services.{CodeConversionError, CompanyAuthService, OAuthToken}
+import services.{CodeAlreadySeen, CodeConversionError, CompanyAuthService, OAuthToken}
 
 import scala.concurrent.Future
 
@@ -30,7 +30,7 @@ class MockCompanyAuth extends CompanyAuthService {
     CompaniesHouseId("000000002") -> "bar@baz.com"
   )
 
-  override def authoriseUrl(companiesHouseId: CompaniesHouseId) = controllers.routes.CoHoOAuthMockController.login(companiesHouseId).url
+  override def authoriseUrl(companiesHouseId: CompaniesHouseId): String = controllers.routes.CoHoOAuthMockController.login(companiesHouseId).url
 
   override def authoriseParams(companiesHouseId: CompaniesHouseId) = Map()
 
@@ -41,9 +41,10 @@ class MockCompanyAuth extends CompanyAuthService {
 
   override def targetScope(companiesHouseId: CompaniesHouseId): String = ""
 
-  override def convertCode(code: String): Future[Either[CodeConversionError, OAuthToken]] =
-    Future.successful(Right(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken")))
-  //Future.successful(Left(CodeAlreadySeen))
+  override def convertCode(code: String): Future[Either[CodeConversionError, OAuthToken]] = Future.successful {
+    if (code == "error") Left(CodeAlreadySeen)
+    else Right(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken"))
+  }
 
   override def refreshAccessToken(oAuthToken: OAuthToken): Future[OAuthToken] = Future.successful(OAuthToken("accessToken", LocalDateTime.now().plusMinutes(60), "refreshToken"))
 }

--- a/src/main/twirl/views/errors/oauthProblem.scala.html
+++ b/src/main/twirl/views/errors/oauthProblem.scala.html
@@ -1,0 +1,18 @@
+@(id: CompaniesHouseId)
+
+<div id="contentStart" class="scannable-wrapper">
+    <div class="notice">
+        <i class="icon icon-important">
+            <span class="visually-hidden">Warning</span>
+        </i>
+        <strong>
+            We encountered a problem trying to log you in.
+        </strong>
+    </div>
+
+    <h2 class="heading-medium">What happens next</h2>
+
+    <p><a href="@controllers.routes.ReportController.preLogin(id)">Please try again</a>.</p>
+    <p> If you are still having problems, please contact paymentpracticesreporting@@beis.gov.uk. </p>
+
+</div>


### PR DESCRIPTION
Better error handling when the oauth code conversion fails because of a previously seen auth code. There are occasional exceptions in the logs due to this and the user is probably presented with a raw error message on a blank page as a result. This change will show a well-formatted page with a slightly more reassuring error message and a link to start again.

I believe these errors are caused by the user hitting the back button.